### PR TITLE
Light background color for editbold

### DIFF
--- a/electricblue256.ini
+++ b/electricblue256.ini
@@ -102,7 +102,7 @@
 
 [editor]
     _default_ = color254;color235
-    editbold = color235;;bold
+    editbold = color235;color39;bold
     editmarked = color235;color39;bold
     editwhitespace = color56;color234
     editlinestate = color66;color235


### PR DESCRIPTION
Search results in the editor are highlighted in a dark font color on a background of a similar dark color and thus nearly invisible. I propose to use a more visible background color (for example the background color used in editmarked).